### PR TITLE
Fix input foreground color for simple-auth

### DIFF
--- a/r-simple-auth/static/simple-auth.css
+++ b/r-simple-auth/static/simple-auth.css
@@ -32,6 +32,7 @@ label{
 input{
     border: 1px solid #DDD;
     background: #EEE;
+    color: #000;
 }
 
 input[type="submit"]{


### PR DESCRIPTION
The background color on input fields was set, but the foreground color
was still default. If the default foreground color was light, text would
be unreadable.