### PR TITLE
Fix file opening issues in r-simple-ban and r-simple-cache

### DIFF
--- a/r-simple-ban/ban.lisp
+++ b/r-simple-ban/ban.lisp
@@ -29,6 +29,7 @@
   *bans*)
 
 (defun save-bans ()
+  (ensure-directories-exist *ban-file*)
   (with-open-file (stream *ban-file* :direction :output :if-exists :supersede)
     (loop for ip being the hash-keys of *bans*
           for time being the hash-values of *bans*

--- a/r-simple-cache/cache.lisp
+++ b/r-simple-cache/cache.lisp
@@ -47,7 +47,7 @@
        (with-open-file (stream file :direction :output :if-exists :supersede)
          (write-string result stream)))
       ((array (unsigned-byte 8))
-       (with-open-file (stream file :direction :output :if-exists :supersede :element-type '(array (unsigned-byte 8)))
+       (with-open-file (stream file :direction :output :if-exists :supersede :element-type '(unsigned-byte 8))
          (write-sequence result stream)))))
   result)
 

--- a/r-simple-cache/cache.lisp
+++ b/r-simple-cache/cache.lisp
@@ -30,11 +30,13 @@
   (merge-pathnames (format NIL "~a/~a" (package-name (symbol-package symbol)) (symbol-name symbol)) *cache-directory*))
 
 (defun cache:get (name)
-  (alexandria:read-file-into-byte-vector
-   (cache::file name)))
+  (when (cache::exists name)
+    (alexandria:read-file-into-byte-vector
+     (cache::file name))))
 
 (defun cache:renew (name)
-  (delete-file (cache::file name)))
+  (when (cache::exists name)
+    (delete-file (cache::file name))))
 
 (defun cache::exists (name)
   (probe-file (cache::file name)))


### PR DESCRIPTION
- r-simple-ban tried to save bans to a file in a nonexistent directory
- r-simple-cache didn't use a proper stream element type for byte arrays
- r-simple-cache threw errors when trying to get or renew nonexistent cache keys

  This one I'm unsure about. The interface doesn't specify what happens when a key doesn't exist

Another issue with r-simple-cache is that it always returns byte arrays, even when things like strings are cached.