### PR TITLE
i-hunchentoot: Fix implementation of providing body-stream

### DIFF
--- a/i-hunchentoot/i-hunchentoot.lisp
+++ b/i-hunchentoot/i-hunchentoot.lisp
@@ -133,8 +133,9 @@
               ;; Cut off starting slash.
               :path (subseq (the string (hunchentoot:script-name request)) 1))
              :http-method (hunchentoot:request-method request)
-             :body-stream (hunchentoot:raw-post-data :request request
-                                                     :want-stream t)
+             :body-stream (unless (hunchentoot:post-parameters request)
+                            (hunchentoot:raw-post-data :request request
+                                                       :want-stream t))
              :headers (hunchentoot:headers-in request)
              :post (hunchentoot:post-parameters request)
              :get (hunchentoot:get-parameters request)


### PR DESCRIPTION
The previous implementation caused hunchentoot to fail with 400 bad
request when sending post requests with data. The solution is to check
for existence of post-parameters and only provide body-stream if they
don't exist.