### PR TITLE
i-woo: Also decode GET parameter values

### DIFF
--- a/i-woo/i-woo.lisp
+++ b/i-woo/i-woo.lisp
@@ -76,7 +76,7 @@
           do (let ((pos (position #\= pair)))
                (when pos
                  (let ((key (url-decode (subseq pair 0 pos)))
-                       (val (subseq pair (1+ pos))))
+                       (val (url-decode (subseq pair (1+ pos)))))
                    (if (ends-with "[]" key)
                        (push val (gethash key table))
                        (setf (gethash key table) val))))))


### PR DESCRIPTION
In url-decode we only decode the key but not the value, which makes
the third of the GET requests test (the one with the mail address) in
radiance-test fail.