### PR TITLE
Add required fields to error declarations

### DIFF
--- a/i-lambdalite/database.lisp
+++ b/i-lambdalite/database.lisp
@@ -39,7 +39,7 @@
   (typecase thing
     (string
      (unless (valid-name-p thing)
-       (error 'db:invalid-collection :collection thing))
+       (error 'db:invalid-collection :database *db-name* :collection thing))
      (intern (map 'string (lambda (c) (if (char= c #\/)
                                           #+windows #\;
                                           #-windows #\:
@@ -137,13 +137,13 @@
                     (:id (typep (second type) '(or symbol string)))
                     (:integer (typep (second type) '(integer 1 8)))
                     (:varchar (typep (second type) '(integer 1))))))
-    (error 'db:invalid-field :field field)))
+    (error 'db:invalid-field :database *db-name* :field field)))
 
 (defun check-field-name (field)
   (unless (typecase field
             (string (valid-name-p field))
             (symbol (valid-name-p (string field))))
-    (error 'db:invalid-field :field field)))
+    (error 'db:invalid-field :database *db-name* :field field)))
 
 (defun db:create (collection structure &key indices (if-exists :ignore))
   (declare (ignore indices))
@@ -170,7 +170,7 @@
 
 (defun db:drop (collection)
   (unless (db:structure collection)
-    (error 'db:invalid-collection :collection collection))
+    (error 'db:invalid-collection :database *db-name* :collection collection))
   (let ((collection (ensure-collection collection)))
     (lambdalite:del :schemas (lambdalite:where (eql :/name collection)))
     (lambdalite::with-lock

--- a/i-postmodern/database.lisp
+++ b/i-postmodern/database.lisp
@@ -56,7 +56,7 @@
       T)))
 
 (defun compile-field (field)
-  (flet ((err (msg) (error 'db:invalid-field :field field :message msg)))
+  (flet ((err (msg) (error 'db:invalid-field :database *current-db* :field field :message msg)))
     (destructuring-bind (name type) field
       (let ((arg (when (listp type) (prog1 (second type) (setf type (first type)))))
             (name (string-downcase name)))

--- a/i-sqlite/database.lisp
+++ b/i-sqlite/database.lisp
@@ -51,7 +51,7 @@
         collection))))
 
 (defun compile-field (field)
-  (flet ((err (msg) (error 'db:invalid-field :field field :message msg)))
+  (flet ((err (msg) (error 'db:invalid-field :database *current-db* :field field :message msg)))
     (destructuring-bind (name type) field
       (unless (valid-name-p name)
         (err "Invalid name, only a-z, - and _ are allowed."))
@@ -76,7 +76,7 @@
            (when arg (err "BOOLEAN cannot accept an argument."))
            (format NIL "~s BOOLEAN" (string-downcase name)))
           (T
-           (error 'db:invalid-field :field arg)))))))
+           (error 'db:invalid-field :database *current-db* :field arg)))))))
 
 (defun db:structure (collection)
   (etypecase collection

--- a/i-sqlite/toolkit.lisp
+++ b/i-sqlite/toolkit.lisp
@@ -29,7 +29,7 @@
                       (symbol (format NIL "~a/~a"
                                       (package-name (symbol-package name)) (symbol-name name))))))
     (unless (valid-name-p collection)
-      (error 'db:invalid-collection :collection collection :message "Invalid name, only a-z, - and _ are allowed."))
+      (error 'db:invalid-collection :database *current-db* :collection collection :message "Invalid name, only a-z, - and _ are allowed."))
     collection))
 
 (defun ensure-collection-name (name &optional check-exists)
@@ -38,5 +38,5 @@
       (let ((collection (coerce-collection-name name)))
         (when check-exists
           (when (= 0 (db:count "sqlite_master" (db:query (:and (:= 'type "table") (:= 'name collection)))))
-            (error 'db:invalid-collection :collection collection :message "Collection does not exist on database.")))
+            (error 'db:invalid-collection :database *current-db* :collection collection :message "Collection does not exist on database.")))
         (prin1-to-string collection))))


### PR DESCRIPTION
A recent fix to `modularize-interfaces` breaks some thrown errors, particularily in the database implementations. The database argument to these conditions were not bound.