### PR TITLE
Fix/improve database invalid field error throwing

### DIFF
--- a/i-postmodern/database.lisp
+++ b/i-postmodern/database.lisp
@@ -62,7 +62,7 @@
             (name (string-downcase name)))
         (unless (valid-name-p name)
           (err "Invalid name, only a-z, - and _ are allowed."))
-        (ecase type
+        (case type
           (:ID
            (format NIL "~s INTEGER~@[ REFERENCES ~a(\"_id\")~]"
                    name (when arg (ensure-collection-name arg))))
@@ -85,7 +85,9 @@
            (format NIL "~s VARCHAR(~d)" name arg))
           (:TEXT
            (when arg (err "TEXT cannot accept an argument."))
-           (format NIL "~s TEXT" name)))))))
+           (format NIL "~s TEXT" name))
+	  (T
+	   (err "Unrecognized field type.")))))))
 
 (defun db:structure (collection)
   (with-connection

--- a/i-sqlite/database.lisp
+++ b/i-sqlite/database.lisp
@@ -76,7 +76,7 @@
            (when arg (err "BOOLEAN cannot accept an argument."))
            (format NIL "~s BOOLEAN" (string-downcase name)))
           (T
-           (error 'db:invalid-field :database *current-db* :field arg)))))))
+	   (err "Unrecognized field type.")))))))
 
 (defun db:structure (collection)
   (etypecase collection


### PR DESCRIPTION
In the case of the SQLITE implementation the `FIELD` slot of `INVALID-FIELD` was being populated to NIL or a useless value when the type checking fell through all cases. Fixed this and consistency of error checking in postmodern implementation