### PR TITLE
Fix: Removing user had him removed from the DB but not from the cache.

### DIFF
--- a/r-simple-users/users.lisp
+++ b/r-simple-users/users.lisp
@@ -111,6 +111,8 @@
     (db:with-transaction ()
       (db:remove 'fields (db:query (:= 'uid (id user))))
       (db:remove 'users (db:query (:= '_id (id user))))
+      (remhash (id user) *user-cache*)
+      (remhash (username user) *user-cache*)
       (trigger 'user:remove user)
       (setf (fields user) NIL
             (id user) NIL


### PR DESCRIPTION
So the invalidated user stayed present in user:list.